### PR TITLE
In the example l.35: aug -> Met, ccc -> Pro, aaa -> Lys

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,6 @@ Below are the specifications in written form.  For a diagram, see the picture **
     d. The last peptide in the sequence is always the one before a "STOP" codon--everything afterward, including the first STOP, is ignored.
     e. If there is no "Met" to start the sequence and no "STOP" to end it, no protein sequence is created at all.  
     f. Protein sequences are written as one-letter codes.  The file "peptides.json" contains the relationship between the three- and one-letter codes.
-    g. *Example Translation from RNA*: ggaugcccaaauaa -> [Met, Pro, Arg] == MPK
+    g. *Example Translation from RNA*: ggaugcccaaauaa -> [Met, Pro, Lys] == MPK
 
 Try it out using this [online tool](https://web.expasy.org/translate/) and type in the following sequence: **ttatttgggcatcc** and press the "Translate" button, and look for the protein sequence highlighted in red.


### PR DESCRIPTION
It should be Lys in stead of Arg.